### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single Next.js 16 (App Router, React 19) personal blog (`mamuso.dev`). It is
+filesystem/markdown-driven: no database, no auth, no API routes, and no required env vars.
+Standard commands live in `package.json` scripts and `CLAUDE.md`; only the non-obvious
+caveats are captured here.
+
+### Services
+
+- Next.js dev server: `pnpm dev` (Turbopack) on `http://localhost:3000`. This is the whole product.
+- There are no other services (no backend/DB). Vercel Analytics/Speed Insights are client-only and no-op locally.
+
+### Content lives in a git submodule (required)
+
+- All posts/photos/assets come from the `content/` git submodule (`github.com/mamuso/mamuso.dev.content.git`, public).
+- The app reads `content/posts/` at render time, so pages error with `ENOENT` if the submodule is not populated.
+- The update script runs `git submodule update --init --remote` to populate it; re-run that command manually if `content/` is ever empty.
+
+### Node version gotcha (important)
+
+- `package.json` `engines` requires Node `24.x`.
+- The VM's `node` on `PATH` is v22 (provided at `/exec-daemon/node`) and it shadows nvm even after `nvm use`.
+- A one-time entry in the agent's `~/.bashrc` prepends nvm's Node 24 `bin`, so login/interactive shells (including tmux sessions) get Node 24. Run `pnpm dev` / `pnpm build` from a login shell (e.g. `bash -l`) so Node 24 is active.
+- `pnpm` is installed under Node 24 (via `npm i -g pnpm@10`). `pnpm install` also works under Node 22 (native deps are N-API/ABI-stable), which is why the update script does not force a Node switch.
+
+### Listing pages cache the post list at module load (content-editing gotcha)
+
+- The homepage (`/`) and `/notes` build their post list from a top-level `const` + React `cache()` in `lib/api.tsx`, evaluated once when the module first loads.
+- Newly added or edited markdown files in `content/posts/` do NOT appear on those listing pages until the dev server is restarted.
+- Individual `/note/[slug]` pages read per-request, so they reflect new/edited content immediately.
+
+### Content pipeline scripts
+
+- `pnpm run assets` copies `content/assets` → `public/assets` (needed for images to load locally).
+- `pnpm run rss` generates `public/feed.xml` (needed to test `/feed.xml`).
+- `pnpm run photos` processes new originals in `content/assets/originals/` (only when adding photos).
+- `pnpm build` runs the submodule update + `assets` + `rss` + `next build`; prefer `pnpm dev` for development.
+
+### Lint
+
+- `pnpm lint` (`eslint .`) — passes clean on a fresh setup.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `mamuso.dev` Next.js blog so it can be run, linted, and tested end to end in Cursor Cloud. The only code change is adding `AGENTS.md`; everything else is environment configuration captured in the update script.

## What was set up

- **Node 24.x** (`engines` requirement) via nvm, made default. Since the VM's default `node` on `PATH` is v22 (`/exec-daemon/node`) and shadows nvm, a one-time `~/.bashrc` entry prepends nvm's Node 24 bin so login/interactive shells (and tmux) use Node 24.
- **pnpm 10** installed under Node 24.
- **Dependencies** installed with `pnpm install` (native deps `sharp`, `@parcel/watcher`, `unrs-resolver` built successfully).
- **`content` git submodule** initialized (`git submodule update --init --remote`) — required, since pages read `content/posts/` at render time.

## Verification

| Task | Command | Result |
| --- | --- | --- |
| Lint | `pnpm lint` | Passes clean |
| Content pipeline | `pnpm run assets` / `pnpm run rss` | Copies assets, generates `public/feed.xml` |
| Run (dev) | `pnpm dev` | Serves on `http://localhost:3000`; `/`, `/notes`, `/photos`, `/feed.xml`, `/note/[slug]` all return 200 |

**Hello-world:** Authored a new markdown note in the content submodule and verified it renders live (homepage Journal + its own `/note/` page), then navigated the site in the browser (opening the note and the photo gallery). The temporary note was removed afterward.

[mamuso_dev_end_to_end_demo.mp4](https://cursor.com/agents/bc-996442f2-319c-4593-96c5-0041b53ce3f2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmamuso_dev_end_to_end_demo.mp4)

[mamuso.dev homepage with new note at top of Journal](https://cursor.com/agents/bc-996442f2-319c-4593-96c5-0041b53ce3f2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmamuso_dev_homepage.webp)

## Notes

- `AGENTS.md` documents non-obvious caveats for future agents: the Node PATH gotcha, the required content submodule, and that listing pages (`/`, `/notes`) cache the post list at module load (new markdown only shows after a dev-server restart, while `/note/[slug]` updates immediately).
- Update script (dependency refresh only): sources nvm, updates the content submodule, and runs `pnpm install`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-996442f2-319c-4593-96c5-0041b53ce3f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-996442f2-319c-4593-96c5-0041b53ce3f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

